### PR TITLE
Using SDK Version variables from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,19 +4,27 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:3.1.2'
     }
 }
 
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext
+
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
     }
@@ -30,5 +38,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+' // from node_modules
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
 }


### PR DESCRIPTION
Instead of assuming the compileSdkVersion, targetSdkVersion, etc, read it from the root project.
Default compileSdkVersion and targetSdkVersion to the latest versions.

Android Target API Level 26 will be required in August 2018.
https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html

And the React Native team is already working on this:
facebook/react-native#17741
facebook/react-native#18095

Ref: [Original PR](https://github.com/luggit/react-native-config/pull/248)